### PR TITLE
Link to our own license (MPL) instead of upstream's license (BUSL) in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ This repository contains only Terraform core, which includes the command line in
 
 ## License
 
-[Mozilla Public License v2.0](https://github.com/hashicorp/terraform/blob/main/LICENSE)
+[Mozilla Public License v2.0](https://github.com/diggerhq/open-terraform/blob/main/LICENSE)


### PR DESCRIPTION
Exactly what it says on the tin.  Caught me off guard when I clicked on the link and it brought me to the BUSL.